### PR TITLE
grunt task for testing with litmus

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,6 +72,19 @@ module.exports = function(grunt) {
             }
         },
 
+        litmus: {
+            test: {
+                src: ['<%= path.build %>/<%= config.template %>'], 
+                options: {
+                    username: '<%= config.litmus.username %>',
+                    password: '<%= config.litmus.password %>',
+                    url: '<%= config.litmus.url %>',
+                    clients: ['gmailnew', 'ffgmailnew', 'chromegmailnew'],
+                    subject: '<%= config.mail.subject %>'
+                }
+            } 
+        },
+
         connect: {
             server: {
                 options: {
@@ -106,4 +119,5 @@ module.exports = function(grunt) {
     grunt.registerTask('default', ['connect', 'open', 'watch']);
     grunt.registerTask('build', ['sass', 'emailBuilder', 'copy', 'imageEmbed']);
     grunt.registerTask('test', ['build', 'nodemailer']);
+    grunt.registerTask('test:litmus', ['build', 'litmus']);
 };

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Install dependencies
 
 Run
 
-    grunt build // to build mail
-    grunt test  // to send a testmail (adjust config.yml)
-    grunt       // starts connect server for easy developing
+    grunt build 				// to build mail
+    grunt test  				// to send a testmail (adjust config.yml)
+		grunt test:litmus		// to test your mail with litmus (adjust config.yml)
+    grunt      					// starts connect server for easy developing

--- a/config.yml
+++ b/config.yml
@@ -5,4 +5,9 @@ mail:
     name:  Marian Friedmann
     email: marian.friedmann@gmail.com
 
+litmus:
+  username: user@domain.com
+  password: supersecretpassword
+  url: https://yourcompany.litmus.com 
+
 template:  mail.html

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-email-builder": "^2.0.0",
     "grunt-image-embed-src": "^0.1.1",
+    "grunt-litmus": "^0.1.8",
     "grunt-nodemailer": "^0.2.0",
     "grunt-open": "^0.2.3",
     "load-grunt-tasks": "^0.4.0"


### PR DESCRIPTION
this adds a `test:litmus` task to send your mails to litmus (`config.yml` needs to be edited in order to work). more config options can be found [here](https://github.com/jeremypeter/grunt-litmus) – maybe it makes sense to add better client defaults? (looking at you outlook!).